### PR TITLE
Standardise html format for a consistent import

### DIFF
--- a/src/Tasks/EmailImportTask.php
+++ b/src/Tasks/EmailImportTask.php
@@ -386,7 +386,7 @@ class EmailImportTask extends BuildTask
             $emailTemplate->Content = '';
             $emailTemplate->Content = $cleanContent;
 
-            $source = '<div>' . $content . '</div>';
+            $source = '<!DOCTYPE html><html><body>' . $content . '</body></html>';
             $dom = new DomDocument('1.0', 'UTF-8');
             $dom->loadHTML(mb_convert_encoding($source, 'HTML-ENTITIES', 'UTF-8'));
 


### PR DESCRIPTION
There was an issue when when I run EmailTaskImport.

I believe it is because of an older version of libxml2 or DOM. Because it works on my localhost and doesn't import correctly when I run on my development server.

Troubleshooting finds that `getElementById` doesn't successfully get the node.

I believe it is because the html is not structured properly and caused an issue in an older version of libxml or DOM.

I have tested that making this change works on both my localhost and development server.