### PR TITLE
Format ReplyTo like to rest of the email addresses

### DIFF
--- a/src/Email/BetterEmail.php
+++ b/src/Email/BetterEmail.php
@@ -124,7 +124,7 @@ class BetterEmail extends Email
         $record = SentEmail::create(array(
             'To' => EmailUtils::format_email_addresses($this->getTo()),
             'From' => EmailUtils::format_email_addresses($this->getFrom()),
-            'ReplyTo' => $this->getReplyTo(),
+            'ReplyTo' => EmailUtils::format_email_addresses($this->getReplyTo()),
             'Subject' => $this->getSubject(),
             'Body' => $this->getRenderedBody(),
             'Headers' => $this->getSwiftMessage()->getHeaders()->toString(),


### PR DESCRIPTION
Got an error where `Email::getReplyTo()` returns an array and couldn't be created in `SentEmail`

This fixes it.